### PR TITLE
Feature/14 error on missing api key

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -81,15 +81,10 @@ for a 3D map with a basemap loaded from a `PortalId`.
 ### Reference Scripts and Styles
 
 - Add the following lines to the `head` element of your `_Layout.cshtml` (Blazor Server) or `index.html` (Blazor Wasm or Maui Blazor Hybrid)
-- _Note_, for `_Layout.cshtml`/Blazor Server, all the `@` symbols below must be doubled (`@@`) to escape, since `@` is a reserved character in Razor
 
 ```html
     <link href="_content/dymaptic.Blazor.GIS.API.Core"/>
-    <script src="https://unpkg.com/@esri/arcgis-rest-request@3.0.0/dist/umd/request.umd.js"></script>
-    <script src="https://unpkg.com/@esri/arcgis-rest-auth@3.0.0/dist/umd/auth.umd.js"></script>
-    <script src="https://unpkg.com/@esri/arcgis-rest-demographics@3.0.0/dist/umd/demographics.umd.js"></script>
-    <link href="https://js.arcgis.com/4.23/esri/themes/light/main.css" rel="stylesheet">
-    <script src="https://js.arcgis.com/4.23/"></script>
+    <link href="https://js.arcgis.com/4.24/esri/themes/light/main.css" rel="stylesheet">
 ```
 
 ### Setup API Key

--- a/UsingTheAPI.md
+++ b/UsingTheAPI.md
@@ -7,11 +7,7 @@ since the symbol is a reserved character in Razor.
 
 ```html
     <link href="_content/dymaptic.Blazor.GIS.API.Core"/>
-    <script src="https://unpkg.com/@@esri/arcgis-rest-request@@3.0.0/dist/umd/request.umd.js"></script>
-    <script src="https://unpkg.com/@@esri/arcgis-rest-auth@@3.0.0/dist/umd/auth.umd.js"></script>
-    <script src="https://unpkg.com/@@esri/arcgis-rest-demographics@@3.0.0/dist/umd/demographics.umd.js"></script>
-    <link href="https://js.arcgis.com/4.23/esri/themes/light/main.css" rel="stylesheet"/>
-    <script src="https://js.arcgis.com/4.23/"></script>
+    <link href="https://js.arcgis.com/4.24/esri/themes/light/main.css" rel="stylesheet"/>
 ```
 
 Now, you will need to get an ArcGIS API Key from the [Developer Dashboard](https://developers.arcgis.com/dashboard/).
@@ -122,3 +118,38 @@ See the MAUI sample application for some special scenarios around using the API 
 - MAUI applications do not load `appsettings.json` files to `IConfiguration` by default. You will need to call
   `builder.Configuration.AddInMemoryConfiguration` and load the ApiKey from another source, or
   `builderConfiguration.AddJsonFile` to use an `appsettings.json` file.
+
+# Using ArcGIS User Accounts for login
+
+Instead of using an app-based token, there are a few other ways to authenticate with ArcGIS.
+
+## Default ArcGIS JS Login
+
+The JavaScript API provides a default fallback sign-in form if you don't have an API Key or App Token.
+This is convenient, but it is not as secure as an OAuth sign-in flow (see below). To use the default
+sign-in, you need to set a flag, which will also remove the error message you see when running without
+a token.
+
+### Option 1: Add the flag to your `MapView` when instantiating in a Blazor page:
+
+```html
+<MapView AllowDefaultEsriLogin="true">
+    <Map></Map>
+</MapView>
+```
+
+### Option 2: Add the flag to `appsettings.json` or another location loaded into `IConfiguration`:
+
+```json
+{
+    "AllowDefaultEsriLogin": "true"
+}
+```
+
+## OAuth Secure User Login
+
+Eventually, we will try to get this more "baked in" to the library. For now, however, there is an example you
+can see in the Sample applications. Look in `dymaptic.Blazor.GIS.API.Core.Sample.Shared\Shared\MainLayout.razor`.
+You will see that it looks in `IConfiguration` for a `ClientId`, which you can get from the ArcGIS Developer portal.
+If this value is provided, it adds a login button, which calls into the OAuth flow. This is very much a work in
+progress, but reach out to us if you need assistance in implementing.

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
@@ -478,8 +478,13 @@ public partial class MapView : MapComponent
             return;
         }
 
-        if (Rendering || (Map is null && WebMap is null) || ViewJsModule is null ||
-            string.IsNullOrWhiteSpace(ApiKey)) return;
+        if (Rendering || (Map is null && WebMap is null) || ViewJsModule is null) return;
+
+        if (string.IsNullOrWhiteSpace(ApiKey))
+        {
+            ErrorMessage = "No ArcGIS API Key Found. See ReadMe.md for instructions on providing an API Key.";
+            StateHasChanged();
+        }
 
         Rendering = true;
 

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
@@ -496,6 +496,9 @@ public partial class MapView : MapComponent
         if (string.IsNullOrWhiteSpace(ApiKey) && (AllowDefaultEsriLogin is null || !AllowDefaultEsriLogin.Value))
         {
             ErrorMessage = "No ArcGIS API Key Found. See UsingTheAPI.md for instructions on providing an API Key or suppressing this message.";
+#if DEBUG
+            System.Diagnostics.Debug.WriteLine(ErrorMessage);
+#endif
             StateHasChanged();
 
             return;

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
@@ -104,6 +104,9 @@ public partial class MapView : MapComponent
             }
         }
     }
+    
+    [Parameter]
+    public bool? AllowDefaultEsriLogin { get; set; }
 
     [Parameter]
     public Func<Point, Task>? OnClickAsyncHandler { get; set; }
@@ -427,6 +430,16 @@ public partial class MapView : MapComponent
     {
         await base.OnParametersSetAsync();
         ApiKey = Configuration["ArcGISApiKey"];
+
+        if (AllowDefaultEsriLogin is null)
+        {
+            string? setting = Configuration["AllowDefaultEsriLogin"];
+
+            if (setting is not null && bool.TryParse(setting, out var allow))
+            {
+                AllowDefaultEsriLogin = allow;
+            }
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -480,10 +493,12 @@ public partial class MapView : MapComponent
 
         if (Rendering || (Map is null && WebMap is null) || ViewJsModule is null) return;
 
-        if (string.IsNullOrWhiteSpace(ApiKey))
+        if (string.IsNullOrWhiteSpace(ApiKey) && (AllowDefaultEsriLogin is null || !AllowDefaultEsriLogin.Value))
         {
-            ErrorMessage = "No ArcGIS API Key Found. See ReadMe.md for instructions on providing an API Key.";
+            ErrorMessage = "No ArcGIS API Key Found. See UsingTheAPI.md for instructions on providing an API Key or suppressing this message.";
             StateHasChanged();
+
+            return;
         }
 
         Rendering = true;

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
@@ -496,9 +496,7 @@ public partial class MapView : MapComponent
         if (string.IsNullOrWhiteSpace(ApiKey) && (AllowDefaultEsriLogin is null || !AllowDefaultEsriLogin.Value))
         {
             ErrorMessage = "No ArcGIS API Key Found. See UsingTheAPI.md for instructions on providing an API Key or suppressing this message.";
-#if DEBUG
             System.Diagnostics.Debug.WriteLine(ErrorMessage);
-#endif
             StateHasChanged();
 
             return;


### PR DESCRIPTION
Closes #14

- Defaults to showing an Error message, which also points to the `UsingTheAPI.md` documentation file.
- Added documentation on how to suppress the error and use the default login screen.
- Added two ways of providing the flag to suppress the error.
- In the documentation, pointed out that the login screen was not as secure as OAuth, and also pointed out the sample code in `MainLayout.razor` for implementing OAuth login.

We will create a separate gissue for a more thorough OAuth implementation.