### PR TITLE
Feature/22 editor required params

### DIFF
--- a/samples/dymaptic.Blazor.GIS.API.Core.Sample.Shared/Pages/Test.razor
+++ b/samples/dymaptic.Blazor.GIS.API.Core.Sample.Shared/Pages/Test.razor
@@ -3,7 +3,7 @@
 <MapView Class="map-view">
     <Map>
         <FeatureLayer>
-            <PortalItem Id="8444e275037549c1acab02d2626daaee" />
+            <PortalItem />
         </FeatureLayer>
     </Map>
 </MapView>

--- a/samples/dymaptic.Blazor.GIS.API.Core.Sample.Shared/Pages/Test.razor
+++ b/samples/dymaptic.Blazor.GIS.API.Core.Sample.Shared/Pages/Test.razor
@@ -1,0 +1,12 @@
+@page "/Test"
+<h3>Test</h3>
+<MapView Class="map-view">
+    <Map>
+        <FeatureLayer>
+            <PortalItem Id="8444e275037549c1acab02d2626daaee" />
+        </FeatureLayer>
+    </Map>
+</MapView>
+@code {
+    
+}

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Basemap.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Basemap.cs
@@ -55,4 +55,15 @@ public class Basemap : MapComponent
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        PortalItem?.ValidateRequiredChildren();
+
+        foreach (Layer layer in Layers)
+        {
+            layer.ValidateRequiredChildren();
+        }
+    }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Constraints.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Constraints.cs
@@ -80,6 +80,17 @@ public class Constraints: MapComponent
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        Geometry?.ValidateRequiredChildren();
+
+        foreach (LOD lod in Lods)
+        {
+            lod.ValidateRequiredChildren();
+        }
+    }
 }
 
 

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/CustomOverlay.razor
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/CustomOverlay.razor
@@ -10,8 +10,10 @@
 
 @code {
     [Parameter, EditorRequired]
+    [RequiredProperty]
     public OverlayPosition Position { get; set; }
     [Parameter, EditorRequired]
+    [RequiredProperty]
     public RenderFragment? ChildContent { get; set; }
 
     public void Refresh()

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/CustomOverlay.razor
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/CustomOverlay.razor
@@ -9,9 +9,9 @@
 </div>
 
 @code {
-    [Parameter]
+    [Parameter, EditorRequired]
     public OverlayPosition Position { get; set; }
-    [Parameter]
+    [Parameter, EditorRequired]
     public RenderFragment? ChildContent { get; set; }
 
     public void Refresh()

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Geometries/Geometry.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Geometries/Geometry.cs
@@ -67,6 +67,13 @@ public class Geometry : MapComponent
                 break;
         }
     }
+
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        Extent?.ValidateRequiredChildren();
+        SpatialReference?.ValidateRequiredChildren();
+    }
 }
 
 public class GeometryConverter : JsonConverter<Geometry>

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/FeatureLayer.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/FeatureLayer.cs
@@ -8,9 +8,6 @@ namespace dymaptic.Blazor.GIS.API.Core.Components.Layers;
 
 public class FeatureLayer : Layer
 {
-    private string? _definitionExpression;
-    public override string LayerType => "feature";
-
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string Url { get; set; } = default!;
@@ -43,6 +40,8 @@ public class FeatureLayer : Layer
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Renderer? Renderer { get; set; }
+    
+    public override string LayerType => "feature";
 
     public override async Task RegisterChildComponent(MapComponent child)
     {
@@ -112,4 +111,6 @@ public class FeatureLayer : Layer
             await JsModule!.InvokeVoidAsync("updateFeatureLayer", (object)this, View!.Id);
         });
     }
+    
+    private string? _definitionExpression;
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/FeatureLayer.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/FeatureLayer.cs
@@ -10,6 +10,7 @@ public class FeatureLayer : Layer
 {
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [RequiredProperty(nameof(PortalItem))]
     public string Url { get; set; } = default!;
 
     [Parameter]
@@ -41,6 +42,10 @@ public class FeatureLayer : Layer
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Renderer? Renderer { get; set; }
     
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [RequiredProperty(nameof(Url))]
+    public PortalItem? PortalItem { get; set; }
+    
     public override string LayerType => "feature";
 
     public override async Task RegisterChildComponent(MapComponent child)
@@ -71,6 +76,14 @@ public class FeatureLayer : Layer
                 }
 
                 break;
+            case PortalItem portalItem:
+                if (!portalItem.Equals(PortalItem))
+                {
+                    PortalItem = portalItem;
+                    await UpdateComponent();
+                }
+
+                break;
             default:
                 await base.RegisterChildComponent(child);
 
@@ -94,11 +107,27 @@ public class FeatureLayer : Layer
                 Renderer = null;
 
                 break;
+            case PortalItem _:
+                PortalItem = null;
+
+                break;
             default:
                 await base.UnregisterChildComponent(child);
 
                 break;
         }
+    }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        PopupTemplate?.ValidateRequiredChildren();
+        Renderer?.ValidateRequiredChildren();
+        PortalItem?.ValidateRequiredChildren();
+        foreach (var label in LabelingInfo)
+        {
+            label.ValidateRequiredChildren();
+        } 
     }
 
     public override async Task UpdateComponent()

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/Graphic.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/Graphic.cs
@@ -70,6 +70,14 @@ public class Graphic : LayerObject
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        Attributes?.ValidateRequiredChildren();
+        Geometry?.ValidateRequiredChildren();
+        PopupTemplate?.ValidateRequiredChildren();
+    }
 
     public override async Task UpdateComponent()
     {

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/GraphicsLayer.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/GraphicsLayer.cs
@@ -55,4 +55,14 @@ public class GraphicsLayer : Layer
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+
+        foreach (Graphic graphic in Graphics)
+        {
+            graphic.ValidateRequiredChildren();
+        }
+    }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/Label.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/Label.cs
@@ -44,4 +44,10 @@ public class Label : LayerObject
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        LabelExpressionInfo?.ValidateRequiredChildren();
+    }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/LayerObject.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/LayerObject.cs
@@ -4,6 +4,7 @@ namespace dymaptic.Blazor.GIS.API.Core.Components.Layers;
 
 public abstract class LayerObject : MapComponent
 {
+    [RequiredComponent]
     public Symbol? Symbol { get; set; }
 
     public override async Task RegisterChildComponent(MapComponent child)

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/LayerObject.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/LayerObject.cs
@@ -4,7 +4,7 @@ namespace dymaptic.Blazor.GIS.API.Core.Components.Layers;
 
 public abstract class LayerObject : MapComponent
 {
-    [RequiredComponent]
+    [RequiredProperty]
     public Symbol? Symbol { get; set; }
 
     public override async Task RegisterChildComponent(MapComponent child)
@@ -39,5 +39,11 @@ public abstract class LayerObject : MapComponent
 
                 break;
         }
+    }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        Symbol?.ValidateRequiredChildren();
     }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/TileLayer.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/TileLayer.cs
@@ -9,8 +9,10 @@ public class TileLayer : Layer
     public override string LayerType => "tile";
 
     [Parameter]
+    [RequiredProperty(nameof(PortalItem))]
     public string? Url { get; set; }
 
+    [RequiredProperty(nameof(Url))]
     public PortalItem? PortalItem { get; set; }
 
     public override async Task RegisterChildComponent(MapComponent child)
@@ -45,6 +47,12 @@ public class TileLayer : Layer
 
                 break;
         }
+    }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        PortalItem?.ValidateRequiredChildren();
     }
 }
 

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/VisualVariable.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/VisualVariable.cs
@@ -11,7 +11,7 @@ public class VisualVariable : MapComponent
     [Parameter]
     public VisualVariableType VariableType { get; set; } = VisualVariableType.Size;
 
-    [Parameter]
+    [Parameter, EditorRequired]
     public string Field { get; set; } = default!;
 
     [Parameter]

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/VisualVariable.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Layers/VisualVariable.cs
@@ -12,6 +12,7 @@ public class VisualVariable : MapComponent
     public VisualVariableType VariableType { get; set; } = VisualVariableType.Size;
 
     [Parameter, EditorRequired]
+    [RequiredProperty]
     public string Field { get; set; } = default!;
 
     [Parameter]

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Map.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Map.cs
@@ -71,6 +71,17 @@ public class Map : MapComponent
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        Basemap?.ValidateRequiredChildren();
+
+        foreach (Layer layer in Layers)
+        {
+            layer.ValidateRequiredChildren();
+        }
+    }
 
     public override async Task UpdateComponent()
     {

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Map.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Map.cs
@@ -5,15 +5,15 @@ namespace dymaptic.Blazor.GIS.API.Core.Components;
 
 public class Map : MapComponent
 {
-    public Basemap? Basemap { get; set; }
-
-    public HashSet<Layer> Layers { get; set; } = new();
-
     [Parameter]
     public string? ArcGISDefaultBasemap { get; set; }
 
     [Parameter]
     public string? Ground { get; set; }
+    
+    public Basemap? Basemap { get; set; }
+
+    public HashSet<Layer> Layers { get; set; } = new();
 
     public override async Task RegisterChildComponent(MapComponent child)
     {

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/MapComponent.razor.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/MapComponent.razor.cs
@@ -4,6 +4,8 @@ using Microsoft.JSInterop;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using dymaptic.Blazor.GIS.API.Core.Exceptions;
+using System.Collections;
+using System.Reflection;
 
 
 namespace dymaptic.Blazor.GIS.API.Core.Components;
@@ -11,8 +13,6 @@ namespace dymaptic.Blazor.GIS.API.Core.Components;
 [JsonConverter(typeof(MapComponentConverter))]
 public abstract partial class MapComponent : ComponentBase, IAsyncDisposable
 {
-    public Guid Id { get; init; } = Guid.NewGuid();
-
     [Parameter]
     [JsonIgnore]
     public RenderFragment? ChildContent { get; set; }
@@ -32,6 +32,8 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable
     [CascadingParameter(Name = "View")]
     [JsonIgnore]
     public MapView? View { get; set; }
+    
+    public Guid Id { get; init; } = Guid.NewGuid();
 
     public virtual async ValueTask DisposeAsync()
     {
@@ -77,6 +79,33 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable
         }
     }
 
+
+    public void ValidateRequiredChildren()
+    {
+        Type thisType = GetType();
+        IEnumerable<PropertyInfo> parameters = thisType
+            .GetProperties()
+            .Where(p =>
+                Attribute.IsDefined(p, typeof(RequiredComponentAttribute)));
+
+        foreach (PropertyInfo requiredParameter in parameters)
+        {
+            Type propType = requiredParameter.PropertyType;
+            object? value = requiredParameter.GetValue(this);
+
+            if (value is null)
+            {
+                throw new MissingRequiredChildElementException(thisType.Name, propType.Name);
+            }
+
+            // lists, arrays
+            if (propType.GetInterface(nameof(IList)) != null && ((IList)value).Count == 0)
+            {
+                throw new MissingRequiredChildElementException(thisType.Name, propType.Name);
+            }
+        }
+    }
+
     protected override Task OnParametersSetAsync()
     {
         _needsUpdate = true;
@@ -98,6 +127,8 @@ public abstract partial class MapComponent : ComponentBase, IAsyncDisposable
         {
             await Parent.RegisterChildComponent(this);
         }
+        
+        ValidateRequiredChildren();
     }
 
     protected virtual async Task RenderView(bool forceRender = false)

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Popups/FieldInfo.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Popups/FieldInfo.cs
@@ -54,4 +54,10 @@ public class FieldInfo : MapComponent
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        Format?.ValidateRequiredChildren();
+    }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Popups/FieldsPopupContent.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Popups/FieldsPopupContent.cs
@@ -42,4 +42,14 @@ public class FieldsPopupContent : PopupContent
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+
+        foreach (FieldInfo info in FieldInfos)
+        {
+            info.ValidateRequiredChildren();
+        }
+    }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Popups/PopupTemplate.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Popups/PopupTemplate.cs
@@ -5,11 +5,13 @@ namespace dymaptic.Blazor.GIS.API.Core.Components.Popups;
 public class PopupTemplate : MapComponent
 {
     [Parameter]
+    [RequiredProperty(nameof(Content))]
     public string? StringContent { get; set; }
 
     [Parameter]
     public string? Title { get; set; }
 
+    [RequiredProperty(nameof(StringContent))]
     public HashSet<PopupContent> Content { get; set; } = new();
 
     public override async Task RegisterChildComponent(MapComponent child)
@@ -46,6 +48,16 @@ public class PopupTemplate : MapComponent
                 await base.UnregisterChildComponent(child);
 
                 break;
+        }
+    }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+
+        foreach (PopupContent item in Content)
+        {
+            item.ValidateRequiredChildren();
         }
     }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/PortalBasemapsSource.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/PortalBasemapsSource.cs
@@ -49,6 +49,12 @@ public class PortalBasemapsSource: MapComponent
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        Portal?.ValidateRequiredChildren();
+    }
 }
 
 public class Portal : MapComponent

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/PortalBasemapsSource.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/PortalBasemapsSource.cs
@@ -5,9 +5,6 @@ namespace dymaptic.Blazor.GIS.API.Core.Components;
 
 public class PortalBasemapsSource: MapComponent
 {
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public Portal? Portal { get; set; }
-    
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? QueryString { get; set; }
@@ -15,6 +12,9 @@ public class PortalBasemapsSource: MapComponent
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Dictionary<string, string>? QueryParams { get; set; }
+    
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Portal? Portal { get; set; }
 
     public override async Task RegisterChildComponent(MapComponent child)
     {

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/PortalItem.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/PortalItem.cs
@@ -4,6 +4,7 @@ namespace dymaptic.Blazor.GIS.API.Core.Components;
 
 public class PortalItem : MapComponent
 {
-    [Parameter]
-    public new string? Id { get; set; }
+    [Parameter, EditorRequired]
+    [RequiredProperty]
+    public new string Id { get; set; } = default!;
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Renderers/SimpleRenderer.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Renderers/SimpleRenderer.cs
@@ -43,4 +43,14 @@ public class SimpleRenderer : Renderer
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+
+        foreach (VisualVariable variable in VisualVariables)
+        {
+            variable.ValidateRequiredChildren();
+        }
+    }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Symbols/SimpleFillSymbol.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Symbols/SimpleFillSymbol.cs
@@ -50,6 +50,12 @@ public class SimpleFillSymbol : FillSymbol
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        Outline?.ValidateRequiredChildren();
+    }
 }
 
 [JsonConverter(typeof(FillStyleConverter))]

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Symbols/SimpleMarkerSymbol.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Symbols/SimpleMarkerSymbol.cs
@@ -47,4 +47,10 @@ public class SimpleMarkerSymbol : MarkerSymbol
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        Outline?.ValidateRequiredChildren();
+    }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Symbols/TextSymbol.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Symbols/TextSymbol.cs
@@ -48,4 +48,10 @@ public class TextSymbol : Symbol
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        Font?.ValidateRequiredChildren();
+    }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
@@ -16,20 +16,17 @@ namespace dymaptic.Blazor.GIS.API.Core.Components.Views;
 
 public partial class MapView : MapComponent
 {
-    public HashSet<Widget> Widgets { get; set; } = new();
-    public List<Graphic> Graphics { get; set; } = new();
+    [Inject]
+    public IConfiguration Configuration { get; set; } = default!;
+
+    [Inject]
+    public IJSRuntime JsRuntime { get; set; } = default!;
 
     [Parameter]
     public string Style { get; set; } = string.Empty;
 
     [Parameter]
     public string Class { get; set; } = string.Empty;
-
-    [Inject]
-    public IConfiguration Configuration { get; set; } = default!;
-
-    [Inject]
-    public IJSRuntime JsRuntime { get; set; } = default!;
 
     [Parameter]
     public double Latitude
@@ -116,6 +113,44 @@ public partial class MapView : MapComponent
     
     [Parameter]
     public Func<SpatialReference, Task>? OnSpatialReferenceChangedHandler { get; set; }
+    
+    [JSInvokable]
+    public void OnJavascriptError(string error)
+    {
+#if DEBUG
+        ErrorMessage = error.Replace("\n", "<br>");
+        StateHasChanged();
+#endif
+        throw new JavascriptException(error);
+    }
+
+    [JSInvokable]
+    public void OnJavascriptClick(Point mapPoint)
+    {
+        OnClickAsyncHandler?.Invoke(mapPoint);
+    }
+
+    [JSInvokable]
+    public void OnJavascriptPointerMove(Point mapPoint)
+    {
+        OnPointerMoveHandler?.Invoke(mapPoint);
+    }
+
+    [JSInvokable]
+    public void OnViewRendered()
+    {
+        OnMapRenderedHandler?.Invoke();
+    }
+
+    [JSInvokable]
+    public void OnSpatialReferenceChanged(SpatialReference spatialReference)
+    {
+        OnSpatialReferenceChangedHandler?.Invoke(spatialReference);
+    }
+    
+    public HashSet<Widget> Widgets { get; set; } = new();
+    
+    public List<Graphic> Graphics { get; set; } = new();
 
     public Map? Map { get; set; }
 
@@ -159,40 +194,7 @@ public partial class MapView : MapComponent
         NeedsRender = true;
         StateHasChanged();
     }
-
-    [JSInvokable]
-    public void OnJavascriptError(string error)
-    {
-#if DEBUG
-        ErrorMessage = error.Replace("\n", "<br>");
-        StateHasChanged();
-#endif
-        throw new JavascriptException(error);
-    }
-
-    [JSInvokable]
-    public void OnJavascriptClick(Point mapPoint)
-    {
-        OnClickAsyncHandler?.Invoke(mapPoint);
-    }
-
-    [JSInvokable]
-    public void OnJavascriptPointerMove(Point mapPoint)
-    {
-        OnPointerMoveHandler?.Invoke(mapPoint);
-    }
-
-    [JSInvokable]
-    public void OnViewRendered()
-    {
-        OnMapRenderedHandler?.Invoke();
-    }
-
-    [JSInvokable]
-    public void OnSpatialReferenceChanged(SpatialReference spatialReference)
-    {
-        OnSpatialReferenceChangedHandler?.Invoke(spatialReference);
-    }
+    
 
     public override async Task UpdateComponent()
     {
@@ -355,11 +357,7 @@ public partial class MapView : MapComponent
     {
         await ViewJsModule!.InvokeVoidAsync("clearViewGraphics", Id);
     }
-
-    /// <summary>
-    /// </summary>
-    /// <param name="routeSymbol"></param>
-    /// <param name="routeUrl"></param>
+    
     /// <returns>Returns the directions of the route</returns>
     public async Task<Direction[]> DrawRouteAndGetDirections(Symbol routeSymbol, string routeUrl)
     {

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
@@ -152,8 +152,10 @@ public partial class MapView : MapComponent
     
     public List<Graphic> Graphics { get; set; } = new();
 
+    [RequiredProperty(nameof(WebMap), nameof(SceneView.WebScene))]
     public Map? Map { get; set; }
 
+    [RequiredProperty(nameof(Map), nameof(SceneView.WebScene))]
     public WebMap? WebMap { get; set; }
 
     public SpatialReference? SpatialReference
@@ -322,6 +324,25 @@ public partial class MapView : MapComponent
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        Map?.ValidateRequiredChildren();
+        WebMap?.ValidateRequiredChildren();
+        Constraints?.ValidateRequiredChildren();
+        SpatialReference?.ValidateRequiredChildren();
+
+        foreach (Graphic graphic in Graphics)
+        {
+            graphic.ValidateRequiredChildren();
+        }
+
+        foreach (Widget widget in Widgets)
+        {
+            widget.ValidateRequiredChildren();
+        }
+    }
 
     public async Task QueryFeatures(Query query, FeatureLayer featureLayer, Symbol displaySymbol,
         PopupTemplate popupTemplate)
@@ -345,7 +366,8 @@ public partial class MapView : MapComponent
 
     public async Task ShowPopupWithGraphic(Graphic graphic, PopupOptions options)
     {
-        await ViewJsModule!.InvokeVoidAsync("showPopupWithGraphic", (object)graphic, (object)options, Id);
+        await ViewJsModule!.InvokeVoidAsync("showPopupWithGraphic", (object)graphic, 
+            (object)options, Id);
     }
 
     public async Task AddGraphic(Graphic graphic, int? layerIndex = null)
@@ -480,6 +502,7 @@ public partial class MapView : MapComponent
             string.IsNullOrWhiteSpace(ApiKey)) return;
 
         Rendering = true;
+        ValidateRequiredChildren();
 
         await InvokeAsync(async () =>
         {

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Views/SceneView.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Views/SceneView.cs
@@ -13,6 +13,7 @@ public class SceneView : MapView
     [Parameter]
     public double? Tilt { get; set; }
 
+    [RequiredProperty(nameof(MapView.WebMap), nameof(MapView.Map))]
     public WebScene? WebScene { get; set; }
 
     public override async Task RegisterChildComponent(MapComponent child)
@@ -47,6 +48,12 @@ public class SceneView : MapView
 
                 break;
         }
+    }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        WebScene?.ValidateRequiredChildren();
     }
 
     protected override async Task RenderView(bool forceRender = false)

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/WebMap.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/WebMap.cs
@@ -2,6 +2,7 @@
 
 public class WebMap : MapComponent
 {
+    [RequiredProperty]
     public PortalItem? PortalItem { get; set; }
 
     public override async Task RegisterChildComponent(MapComponent child)
@@ -36,5 +37,11 @@ public class WebMap : MapComponent
 
                 break;
         }
+    }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        PortalItem?.ValidateRequiredChildren();
     }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/WebScene.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/WebScene.cs
@@ -2,6 +2,7 @@
 
 public class WebScene : MapComponent
 {
+    [RequiredProperty]
     public PortalItem? PortalItem { get; set; }
 
     public override async Task RegisterChildComponent(MapComponent child)
@@ -36,5 +37,11 @@ public class WebScene : MapComponent
 
                 break;
         }
+    }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        PortalItem?.ValidateRequiredChildren();
     }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Widgets/BasemapGalleryWidget.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Widgets/BasemapGalleryWidget.cs
@@ -46,4 +46,10 @@ public class BasemapGalleryWidget : Widget
                 break;
         }
     }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        PortalBasemapsSource?.ValidateRequiredChildren();
+    }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Widgets/BasemapToggleWidget.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Widgets/BasemapToggleWidget.cs
@@ -7,6 +7,7 @@ public class BasemapToggleWidget : Widget
 {
     [JsonPropertyName("type")]
     public override string WidgetType => "basemapToggle";
-    [Parameter]
+    
+    [Parameter, EditorRequired]
     public string? NextBasemap { get; set; }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Widgets/BasemapToggleWidget.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Widgets/BasemapToggleWidget.cs
@@ -9,5 +9,6 @@ public class BasemapToggleWidget : Widget
     public override string WidgetType => "basemapToggle";
     
     [Parameter, EditorRequired]
+    [RequiredProperty]
     public string? NextBasemap { get; set; }
 }

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Widgets/VisibleElements.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Widgets/VisibleElements.cs
@@ -5,16 +5,16 @@ namespace dymaptic.Blazor.GIS.API.Core.Components.Widgets;
 
 public class VisibleElements : MapComponent
 {
-    public CreateTools? CreateTools { get; set; }
-
-    public SelectionTools? SelectionTools { get; set; }
-
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? SettingsMenu { get; set; }
     [Parameter]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? UndoRedoMenu { get; set; }
+    
+    public CreateTools? CreateTools { get; set; }
+
+    public SelectionTools? SelectionTools { get; set; }
 
     public override async Task RegisterChildComponent(MapComponent child)
     {
@@ -58,6 +58,13 @@ public class VisibleElements : MapComponent
 
                 break;
         }
+    }
+    
+    public override void ValidateRequiredChildren()
+    {
+        base.ValidateRequiredChildren();
+        CreateTools?.ValidateRequiredChildren();
+        SelectionTools?.ValidateRequiredChildren();
     }
 }
 

--- a/src/dymaptic.Blazor.GIS.API.Core/Exceptions/MissingRequiredChildElementException.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Exceptions/MissingRequiredChildElementException.cs
@@ -7,3 +7,11 @@ public class MissingRequiredChildElementException : Exception
     {
     }
 }
+
+public class MissingRequiredOptionsChildElementException : Exception
+{
+    public MissingRequiredOptionsChildElementException(string parentType, IEnumerable<string> options) :
+        base($"One of the types in [ {string.Join(", ", options)} ] must be added as a child of type {parentType}")
+    {
+    }
+}

--- a/src/dymaptic.Blazor.GIS.API.Core/Exceptions/MissingRequiredChildElementException.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Exceptions/MissingRequiredChildElementException.cs
@@ -1,0 +1,9 @@
+﻿namespace dymaptic.Blazor.GIS.API.Core.Exceptions;
+
+public class MissingRequiredChildElementException : Exception
+{
+    public MissingRequiredChildElementException(string parentType, string childType) :
+        base($"The type {childType} must be added as a child of type {parentType}")
+    {
+    }
+}

--- a/src/dymaptic.Blazor.GIS.API.Core/RequiredComponentAttribute.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/RequiredComponentAttribute.cs
@@ -1,5 +1,0 @@
-namespace dymaptic.Blazor.GIS.API.Core;
-
-public class RequiredComponentAttribute: Attribute
-{
-}

--- a/src/dymaptic.Blazor.GIS.API.Core/RequiredComponentAttribute.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/RequiredComponentAttribute.cs
@@ -1,0 +1,5 @@
+namespace dymaptic.Blazor.GIS.API.Core;
+
+public class RequiredComponentAttribute: Attribute
+{
+}

--- a/src/dymaptic.Blazor.GIS.API.Core/RequiredPropertyAttribute.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/RequiredPropertyAttribute.cs
@@ -1,0 +1,33 @@
+using dymaptic.Blazor.GIS.API.Core.Components;
+using dymaptic.Blazor.GIS.API.Core.Exceptions;
+
+namespace dymaptic.Blazor.GIS.API.Core;
+
+/// <summary>
+///     Add this attribute to any property on any subclass of <see cref="MapComponent"/>, and if the user
+///     forgets to set that property, this will throw a <see cref="MissingRequiredChildElementException"/>
+///     or <see cref="MissingRequiredOptionsChildElementException"/>. This works for both `[Parameter]`
+///     properties as well as Child Components registered with `RegisterChildComponent` 
+/// </summary>
+public class RequiredPropertyAttribute: Attribute
+{
+    public string[]? OtherOptions { get; }
+
+    /// <param name="otherOptions">
+    ///     If there are two or more acceptable properties that can be set, add the other property names
+    ///     here for the validation. Use `nameof(Property)` to ensure you get the right name.
+    /// </param>
+    public RequiredPropertyAttribute(params string[]? otherOptions)
+    {
+        OtherOptions = otherOptions;
+    }
+}
+
+/// <summary>
+///     Just a convenience class for <see cref="MapComponent.ValidateRequiredChildren"/>
+/// </summary>
+internal class ComponentOption
+{
+    public List<string> Options { get; } = new();
+    public bool Found { get; set; }
+}

--- a/src/dymaptic.Blazor.GIS.API.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.Blazor.GIS.API.Core/Scripts/arcGisJsInterop.ts
@@ -774,11 +774,21 @@ export async function addLayer(layerObject: any, viewId: string, isBasemapLayer?
                 });
                 break;
             case 'feature':
-                newLayer = new FeatureLayer({
-                    url: layerObject.url,
-                    opacity: layerObject.opacity,
-                    definitionExpression: layerObject.definitionExpression
-                });
+                if (layerObject.portalItem !== undefined && layerObject.portalItem?.id !== null) {
+                    newLayer = new FeatureLayer({
+                        portalItem: {
+                            id: layerObject.portalItem.id
+                        },
+                        opacity: layerObject.opacity,
+                        definitionExpression: layerObject.definitionExpression
+                    });
+                } else {
+                    newLayer = new FeatureLayer({
+                        url: layerObject.url,
+                        opacity: layerObject.opacity,
+                        definitionExpression: layerObject.definitionExpression
+                    });
+                }
                 let featureLayer = newLayer as FeatureLayer;
                 if (layerObject.opacity !== undefined && layerObject.opacity !== null) {
                     newLayer.opacity = layerObject.opacity;


### PR DESCRIPTION
Closes #22 

As mentioned in the gissue, found `EditorRequired` Parameter attribute, and applied where I could. This raises a warning at compile time.

I also decided that I would like something to actually check and throw an understandable error at runtime, both for `[Parameter]` properties and `Child Components` that I register manually. So I created a new attribute, `RequiredPropertyAttribute`, and hooked up all `MapComponents` to call `ValidateRequiredChildren()` right before rendering to JavaScript.

I should also point out I am aware of the new `required` property keyword that is coming in C#11. However, this won't work for our late-bound Child Components, anyways, so a custom solution seemed sensible.