### PR TITLE
Feature/17 free the widgets

### DIFF
--- a/samples/dymaptic.Blazor.GIS.API.Core.Sample.Shared/Pages/Widgets.razor
+++ b/samples/dymaptic.Blazor.GIS.API.Core.Sample.Shared/Pages/Widgets.razor
@@ -23,9 +23,6 @@
         <div class="form-group">
             <label>Scale Bar: <input type="checkbox" @onchange="@(() => ToggleWidget(nameof(ScaleBarWidget)))"></label>
         </div>
-    </div>
-    <div class="widget-container">
-        <label>@(_showBasemapGallery ? "Basemap Gallery" : "")</label>
         <div id="gallery-box"></div>
     </div>
 </div>

--- a/samples/dymaptic.Blazor.GIS.API.Core.Sample.Shared/Pages/Widgets.razor
+++ b/samples/dymaptic.Blazor.GIS.API.Core.Sample.Shared/Pages/Widgets.razor
@@ -3,24 +3,30 @@
 <PageTitle>Widgets</PageTitle>
 <h1>Widgets</h1>
 <a target="_blank" href="https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-support-widget.html">ArcGIS API for JavaScript</a>
-<div id="control-set">
-    <div class="form-group">
-        <label>Locator: <input type="checkbox" @onchange="@(() => ToggleWidget(nameof(LocateWidget)))"></label>
+<div class="control-row">
+    <div id="control-set">
+        <div class="form-group">
+            <label>Locator: <input type="checkbox" @onchange="@(() => ToggleWidget(nameof(LocateWidget)))"></label>
+        </div>
+        <div class="form-group">
+            <label>Search: <input type="checkbox" @onchange="@(() => ToggleWidget(nameof(SearchWidget)))"></label>
+        </div>
+        <div class="form-group">
+            <label>Basemap Toggle: <input type="checkbox" @onchange="@(() => ToggleWidget(nameof(BasemapToggleWidget)))"></label>
+        </div>
+        <div class="form-group">
+            <label>Basemap Gallery: <input type="checkbox" @onchange="@(() => ToggleWidget(nameof(BasemapGalleryWidget)))"></label>
+        </div>
+        <div class="form-group">
+            <label>Legend: <input type="checkbox" @onchange="@(() => ToggleWidget(nameof(LegendWidget)))"></label>
+        </div>
+        <div class="form-group">
+            <label>Scale Bar: <input type="checkbox" @onchange="@(() => ToggleWidget(nameof(ScaleBarWidget)))"></label>
+        </div>
     </div>
-    <div class="form-group">
-        <label>Search: <input type="checkbox" @onchange="@(() => ToggleWidget(nameof(SearchWidget)))"></label>
-    </div>
-    <div class="form-group">
-        <label>Basemap Toggle: <input type="checkbox" @onchange="@(() => ToggleWidget(nameof(BasemapToggleWidget)))"></label>
-    </div>
-    <div class="form-group">
-        <label>Basemap Gallery: <input type="checkbox" @onchange="@(() => ToggleWidget(nameof(BasemapGalleryWidget)))"></label>
-    </div>
-    <div class="form-group">
-        <label>Legend: <input type="checkbox" @onchange="@(() => ToggleWidget(nameof(LegendWidget)))"></label>
-    </div>
-    <div class="form-group">
-        <label>Scale Bar: <input type="checkbox" @onchange="@(() => ToggleWidget(nameof(ScaleBarWidget)))"></label>
+    <div class="widget-container">
+        <label>@(_showBasemapGallery ? "Basemap Gallery" : "")</label>
+        <div id="gallery-box"></div>
     </div>
 </div>
 
@@ -40,7 +46,7 @@
     }
     @if (_showBasemapGallery)
     {
-        <BasemapGalleryWidget Position="OverlayPosition.BottomRight" />
+        <BasemapGalleryWidget ContainerId="gallery-box" />
     }
     @if (_showScaleBar)
     {

--- a/samples/dymaptic.Blazor.GIS.API.Core.Sample.Shared/Pages/Widgets.razor.css
+++ b/samples/dymaptic.Blazor.GIS.API.Core.Sample.Shared/Pages/Widgets.razor.css
@@ -7,22 +7,20 @@
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;
-    width: 45%;
-}
-
-.widget-container {
-    padding: 1rem;
-    max-height: 20rem;
-    position: relative;
-    width: 45%;
+    max-height: 24rem;
+    align-content: space-between;
+    width: 100%;
 }
 
 #gallery-box {
-    height: 100%;
+    position: relative;
+    max-height: 20rem;
+    overflow-y: scroll;
 }
 
 @media (max-width: 799px) {
     #control-set {
-        max-height: 15vh;
+        max-height: 20vh;
+        width: 100%;
     }
 }

--- a/samples/dymaptic.Blazor.GIS.API.Core.Sample.Shared/Pages/Widgets.razor.css
+++ b/samples/dymaptic.Blazor.GIS.API.Core.Sample.Shared/Pages/Widgets.razor.css
@@ -1,7 +1,24 @@
-﻿#control-set {
+﻿.control-row {
+    display: flex;
+    flex-direction: row;
+}
+
+#control-set {
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;
+    width: 45%;
+}
+
+.widget-container {
+    padding: 1rem;
+    max-height: 20rem;
+    position: relative;
+    width: 45%;
+}
+
+#gallery-box {
+    height: 100%;
 }
 
 @media (max-width: 799px) {

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Views/MapView.razor.cs
@@ -233,7 +233,7 @@ public partial class MapView : MapComponent
                 if (!Widgets.Contains(widget))
                 {
                     Widgets.Add(widget);
-
+                    widget.Parent ??= this;
                     if (MapRendered)
                     {
                         await AddWidget(widget);
@@ -433,26 +433,7 @@ public partial class MapView : MapComponent
     {
         if (firstRender)
         {
-            LicenseType licenseType = Licensing.GetLicenseType();
-            
-            switch ((int)licenseType)
-            {
-                case >= 100:
-                    // this is here to support the interactive extension library
-                    IJSObjectReference interactiveModule = await JsRuntime
-                        .InvokeAsync<IJSObjectReference>("import",
-                            "./_content/dymaptic.Blazor.GIS.API.Interactive/js/arcGisInteractive.js");
-                    ViewJsModule = await interactiveModule.InvokeAsync<IJSObjectReference>("getCore");
-
-                    break;
-                default:
-                    ViewJsModule = await JsRuntime
-                        .InvokeAsync<IJSObjectReference>("import",
-                            "./_content/dymaptic.Blazor.GIS.API.Core/js/arcGisJsInterop.js");
-
-                    break;
-            }
-            
+            ViewJsModule = await JsModuleManager.GetJsModule(JsRuntime);
             JsModule = ViewJsModule;
             // the first render never has all the child components registered
             Rendering = false;

--- a/src/dymaptic.Blazor.GIS.API.Core/Components/Widgets/Widget.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/Components/Widgets/Widget.cs
@@ -9,6 +9,10 @@ public abstract class Widget : MapComponent
 {
     [Parameter]
     public OverlayPosition? Position { get; set; }
+    
+    [Parameter]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ContainerId { get; set; }
 
     [JsonPropertyName("type")]
     public abstract string WidgetType { get; }

--- a/src/dymaptic.Blazor.GIS.API.Core/JsModuleManager.cs
+++ b/src/dymaptic.Blazor.GIS.API.Core/JsModuleManager.cs
@@ -1,0 +1,32 @@
+using Microsoft.JSInterop;
+
+
+namespace dymaptic.Blazor.GIS.API.Core;
+
+public static class JsModuleManager
+{
+    public static async Task<IJSObjectReference> GetJsModule(IJSRuntime jsRuntime)
+    {
+        LicenseType licenseType = Licensing.GetLicenseType();
+        IJSObjectReference jsModule;
+        switch ((int)licenseType)
+        {
+            case >= 100:
+                // this is here to support the interactive extension library
+                IJSObjectReference interactiveModule = await jsRuntime
+                    .InvokeAsync<IJSObjectReference>("import",
+                        "./_content/dymaptic.Blazor.GIS.API.Interactive/js/arcGisInteractive.js");
+                jsModule = await interactiveModule.InvokeAsync<IJSObjectReference>("getCore");
+
+                break;
+            default:
+                jsModule = await jsRuntime
+                    .InvokeAsync<IJSObjectReference>("import",
+                        "./_content/dymaptic.Blazor.GIS.API.Core/js/arcGisJsInterop.js");
+
+                break;
+        }
+
+        return jsModule;
+    }
+}

--- a/src/dymaptic.Blazor.GIS.API.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.Blazor.GIS.API.Core/Scripts/arcGisJsInterop.ts
@@ -656,9 +656,16 @@ export function displayQueryResults(query: Query, symbol: ArcGisSymbol, popupTem
 export async function addWidget(widget: any, viewId: string): Promise<void> {
     try {
         let view = arcGisObjectRefs[viewId] as MapView;
+        if (arcGisObjectRefs.hasOwnProperty(widget.id)) {
+            // for now just skip if it already exists
+            // later we may want to replace it with a remove and add
+            // if new values are added
+            return;
+        }
+        let newWidget: Widget;
         switch (widget.type) {
             case 'locate':
-                const locate = new Locate({
+                newWidget = new Locate({
                     view: view,
                     useHeadingEnabled: widget.useHeadingEnabled,
                     goToOverride: function (view, options) {
@@ -666,15 +673,14 @@ export async function addWidget(widget: any, viewId: string): Promise<void> {
                         return view.goTo(options.target);
                     }
                 });
-                view.ui.add(locate, widget.position);
-                arcGisObjectRefs[widget.id] = locate;
+                
                 break;
             case 'search':
                 const search = new Search({
                     view: view
                 });
-                view.ui.add(search, widget.position);
-                arcGisObjectRefs[widget.id] = search;
+                newWidget = search;
+                
                 search.on('select-result', (evt) => {
                     widget.searchWidgetObjectReference.invokeMethodAsync('OnSearchSelectResult', {
                         extent: buildDotNetExtent(evt.result.extent),
@@ -684,12 +690,10 @@ export async function addWidget(widget: any, viewId: string): Promise<void> {
                 });
                 break;
             case 'basemapToggle':
-                const basemapToggle = new BasemapToggle({
+                newWidget = new BasemapToggle({
                     view: view,
                     nextBasemap: widget.nextBasemap
                 });
-                view.ui.add(basemapToggle, widget.position);
-                arcGisObjectRefs[widget.id] = basemapToggle;
                 break;
             case 'basemapGallery':
                 let source = new PortalBasemapsSource();
@@ -714,31 +718,35 @@ export async function addWidget(widget: any, viewId: string): Promise<void> {
                         title: widget.title
                     };
                 }
-                const basemapGallery = new BasemapGallery({
+                newWidget = new BasemapGallery({
                     view: view,
                     source: source
                 });
-                view.ui.add(basemapGallery, widget.position);
-                arcGisObjectRefs[widget.id] = basemapGallery;
                 break;
             case 'scaleBar':
                 const scaleBar = new ScaleBar({
                     view: view
                 });
+                newWidget = scaleBar;
                 if (widget.unit !== undefined && widget.unit !== null) {
                     scaleBar.unit = widget.unit;
                 }
-                view.ui.add(scaleBar, widget.position);
-                arcGisObjectRefs[widget.id] = scaleBar;
                 break;
             case 'legend':
-                const legend = new Legend({
+                newWidget = new Legend({
                     view: view
                 });
-                view.ui.add(legend, widget.position);
-                arcGisObjectRefs[widget.id] = legend;
                 break;
+            default:
+                return;
         }
+
+        if (widget.containerId !== undefined && widget.containerId !== null) {
+            newWidget.container = widget.containerId;
+        } else {
+            view.ui.add(newWidget, widget.position);
+        }
+        arcGisObjectRefs[widget.id] = newWidget;
     } catch (error) {
         logError(error, viewId);
     }

--- a/src/dymaptic.Blazor.GIS.API.Core/Scripts/arcGisJsInterop.ts
+++ b/src/dymaptic.Blazor.GIS.API.Core/Scripts/arcGisJsInterop.ts
@@ -742,7 +742,10 @@ export async function addWidget(widget: any, viewId: string): Promise<void> {
         }
 
         if (widget.containerId !== undefined && widget.containerId !== null) {
-            newWidget.container = widget.containerId;
+            let container = document.getElementById(widget.containerId);
+            let innerContainer = document.createElement('div');
+            container?.appendChild(innerContainer);
+            newWidget.container = innerContainer;
         } else {
             view.ui.add(newWidget, widget.position);
         }

--- a/src/dymaptic.Blazor.GIS.API.Core/dymaptic.Blazor.GIS.API.Core.csproj
+++ b/src/dymaptic.Blazor.GIS.API.Core/dymaptic.Blazor.GIS.API.Core.csproj
@@ -51,6 +51,10 @@
     <ItemGroup>
       <Folder Include="wwwroot\js" />
     </ItemGroup>
+
+    <ItemGroup>
+      <Compile Remove="Exceptions\MissingContainerReferenceException.cs" />
+    </ItemGroup>
     
     <Target Name="NPM Install" AfterTargets="PreBuildEvent">
         <Exec Command="npm install" />


### PR DESCRIPTION
This turned out to be a bit harder than I anticipated, and raised an important issue to be aware of.

When a Blazor page loads, it goes through multiple render cycles. On each cycle, the components are recreated. This makes references to _sibling_ components very hard. The `Id` regenerates, and you end up with a stale reference. There are ways around it, but it would all have to be exposed at the consumer level, or require incredible hackery I haven't yet discovered.

So, instead, I opted to require leaving the declared widget _inside_ the `MapView` in razor, which gives it the correct parent-child references, and then give it an external `ContainerId` which points to a div where you want it to actually render. This makes it fairly inline with the use of `OverlayPosition`.

```html
<div id="gallery-box"></div>
<MapView>
    <BasemapGalleryWidget ContainerId="gallery-box" />
</MapView>
```

One other issue I ran into is that _destroying_ a widget also removes the container. I fixed this by wrapping in an extra container in the JavaScript.